### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -114,7 +114,6 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        from urllib.parse import urlparse
         host = urlparse(origin).hostname
         if host and (host == "modac.cancer.gov" or host.endswith(".modac.cancer.gov")):
             get_file_from_modac(fpath, origin)

--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from urllib.parse import urlparse
 
 import tarfile
 import os
@@ -113,7 +114,9 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        host = urlparse(origin).hostname
+        if host and (host == "modac.cancer.gov" or host.endswith(".modac.cancer.gov")):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot2-Autoencoder_MD_Simulation_Data/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot2-Autoencoder_MD_Simulation_Data/security/code-scanning/1)

To fix the issue, the code should parse the `origin` URL using `urllib.parse.urlparse` and validate its hostname. This ensures that the check is performed on the actual domain name rather than an arbitrary substring. Specifically, the hostname should match `modac.cancer.gov` exactly or end with `.modac.cancer.gov` to allow subdomains.

Changes required:
1. Import `urlparse` from `urllib.parse`.
2. Replace the substring check `'modac.cancer.gov' in origin` with a hostname validation using `urlparse(origin).hostname`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
